### PR TITLE
DEVPROD-3611: upgrade Go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,3 @@ linters:
     - ineffassign
     - misspell
     - unconvert
-
-linters-settings:
-  govet:
-    check-shadowing: false

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -97,7 +97,7 @@ buildvariants:
   - name: lint
     display_name: Lint
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
     run_on:
       - ubuntu2204-small
     tasks:
@@ -106,7 +106,7 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 22.04
     expansions:
-      GOROOT: /opt/golang/go1.20
+      GOROOT: /opt/golang/go1.24
     run_on:
       - ubuntu2204-small
     tasks:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evergreen-ci/mrpc
 
-go 1.20
+go 1.24
 
 require (
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb

--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ htmlCoverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(targ
 
 # start lint setup targets
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.51.2 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.64.5 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
[DEVPROD-3611](https://jira.mongodb.org/browse/DEVPROD-3611)

* Upgrade to Go 1.24.
* Upgrade golangci-lint to support Go 1.24.
* Remove some old linters that are now invalid.